### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,9 @@
 
 # Installation (with composer)
 
-```json
-{
-	"require": {
-		"camspiers/porter-stemmer": "1.0.0"
-	}
-}
+```sh
+composer require camspiers/porter-stemmer
 ```
-
-	$ composer install
 
 # Usage
 


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
