### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/src/Porter.php
+++ b/src/Porter.php
@@ -402,7 +402,7 @@ class Porter
     {
         $c = self::$regex_consonant;
 
-        return preg_match("#$c{2}$#", $str, $matches) AND $matches[0]{0} == $matches[0]{1};
+        return preg_match("#$c{2}$#", $str, $matches) AND $matches[0][0] == $matches[0][1];
     }
 
     /**
@@ -419,8 +419,8 @@ class Porter
 
         return     preg_match("#($c$v$c)$#", $str, $matches)
                AND strlen($matches[1]) == 3
-               AND $matches[1]{2} != 'w'
-               AND $matches[1]{2} != 'x'
-               AND $matches[1]{2} != 'y';
+               AND $matches[1][2] != 'w'
+               AND $matches[1][2] != 'x'
+               AND $matches[1][2] != 'y';
     }
 }


### PR DESCRIPTION
- Fixed "Deprecated: Array and string offset access syntax with curly braces" (PHP 7.4)